### PR TITLE
Edit bad url syntax

### DIFF
--- a/notebooks/jaxrs.ipynb
+++ b/notebooks/jaxrs.ipynb
@@ -13,7 +13,7 @@
     "\n",
     "**Emmanuel BRUNO [✉](mailto:emmanuel.bruno@univ-tln.fr?subject=[Notebook%20JAX-RS]) [☖](http://bruno.univ-tln.fr)**\n",
     "\n",
-    "Ce document présente les service Web REST en général et par la pratique en Java. Il s'appuie sur un exemple simple d'application : https://github.com/ebpro/sample-jaxrsqui servira à illustrer les notions et sera étudiée en détail dans la partie pratique."
+    "Ce document présente les service Web REST en général et par la pratique en Java. Il s'appuie sur un exemple simple d'application : https://github.com/ebpro/sample-jaxrs qui servira à illustrer les notions et sera étudiée en détail dans la partie pratique."
    ]
   },
   {


### PR DESCRIPTION
L'URL vers lien github du projet sample-jaxrs était concaténé avec le mot "qui"